### PR TITLE
Feat: add support for eip1550 and gas estimation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,7 @@ async function callOracle (
   )
 
   // Wait until the network has heen established
-  await provider.ready()
+  await provider.ready
 
   // Check if network supports EIP1559
   const SUPPORTS_EIP1559 = Boolean(await provider.getBlock("latest").baseFee)

--- a/src/index.js
+++ b/src/index.js
@@ -137,7 +137,7 @@ async function callOracle (
   await provider.ready()
 
   // Check if network supports EIP1559
-  const SUPPORTS_EIP1559 = Boolean(await provider.getBlock("latest")).baseFee)
+  const SUPPORTS_EIP1559 = Boolean(await provider.getBlock("latest").baseFee)
 
   // Calculate fees
   const feeData = await provider.getFeeData()
@@ -147,7 +147,7 @@ async function callOracle (
     OVERRIDES = {
       gasLimit: 1400000,
       maxFeePerGas: feeData.maxFeePerGas,
-      maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
+      maxPriorityFeePerGas: feeData.maxPriorityFeePerGas
     }
   } else {
     OVERRIDES = {


### PR DESCRIPTION
Now that we will deploy the service on other networks like polygon. We were having issues with having a hardcode `gasPrice` of 1.

The PR includes:
- Support for EIP1559 if we detect the network supports it.
- Handle the [`provider.getFeeData()`](https://docs.ethers.io/v5/api/providers/provider/#Provider-getFeeData) method and overrides the corresponding tx parameters.